### PR TITLE
Fix table size

### DIFF
--- a/src/parser/high-level.ts
+++ b/src/parser/high-level.ts
@@ -275,9 +275,10 @@ export const setStoragePointerConstants = (
         // Store the macro definition.
         const definition = body.match(MACRO_CODE.MACRO_CALL);
         const macroName = definition[1];
-
-        // Get the used storage pointer constants.
-        getUsedStoragePointerConstants(macroName, true);
+        if (macroName.startsWith("__")) {
+          // Get the used storage pointer constants.
+          getUsedStoragePointerConstants(macroName, true);
+        }
 
         // Slice the body.
         body = body.slice(definition[0].length);

--- a/src/parser/high-level.ts
+++ b/src/parser/high-level.ts
@@ -275,7 +275,7 @@ export const setStoragePointerConstants = (
         // Store the macro definition.
         const definition = body.match(MACRO_CODE.MACRO_CALL);
         const macroName = definition[1];
-        if (macroName.startsWith("__")) {
+        if (!macroName.startsWith("__")) {
           // Get the used storage pointer constants.
           getUsedStoragePointerConstants(macroName, true);
         }

--- a/src/parser/macros.ts
+++ b/src/parser/macros.ts
@@ -30,9 +30,7 @@ const parseMacro = (
     // Check if we're parsing a macro call.
     if (
       input.match(MACRO_CODE.MACRO_CALL) &&
-      !(input.match(MACRO_CODE.MACRO_CALL) ? input.match(MACRO_CODE.MACRO_CALL)[1] : "").startsWith(
-        "__"
-      )
+      !(input.match(MACRO_CODE.MACRO_CALL)![1] || "").startsWith("__")
     ) {
       // Parse the macro call.
       token = input.match(MACRO_CODE.MACRO_CALL);
@@ -93,7 +91,7 @@ const parseMacro = (
       if (!jumptables[name]) throw new Error(`Table ${name} is not defined`);
 
       // Get the size of the table.
-      const hex = formatEvenBytes(toHex(jumptables[name].value.length));
+      const hex = formatEvenBytes(toHex(jumptables[name].args[1]));
 
       // Add the table_size call to the token list.
       operations.push({ type: OperationType.PUSH, value: toHex(95 + hex.length / 2), args: [hex] });

--- a/src/parser/syntax/reserved.ts
+++ b/src/parser/syntax/reserved.ts
@@ -1,0 +1,5 @@
+export const RESERVED_KEYWORDS = [
+  "__codesize",
+  "__tablesize",
+  "__tablestart"
+];


### PR DESCRIPTION
Resolved 2 bugs related to the `__tablesize` function in the parser:
- using the length of the table's body string as the size
- treating the function as a macro when processing storage constants
