### PR TITLE
Fix incorrect sizing of constants and address issue with file reader

### DIFF
--- a/src/parser/high-level.ts
+++ b/src/parser/high-level.ts
@@ -6,7 +6,7 @@ import { HIGH_LEVEL, MACRO_CODE } from "./syntax/defintions";
 import { parseArgs, getLineNumber } from "./utils/parsing";
 import { parseCodeTable, parseJumpTable } from "./tables";
 import parseMacro from "./macros";
-import { convertBytesToNumber, convertNumberToBytes, findLowest } from "../utils/bytes";
+import { convertBytesToNumber, convertNumberToBytes, findLowest, formatEvenBytes } from "../utils/bytes";
 
 /**
  * Parse a file, storing the definitions of all constants, macros, and tables.
@@ -65,7 +65,7 @@ export const parseFile = (
         // Parse constant definition.
         const constant = input.match(HIGH_LEVEL.CONSTANT);
         const name = constant[2];
-        const value = constant[3].replace("0x", "");
+        const value = formatEvenBytes(constant[3].replace("0x", ""));
 
         // Ensure that the constant name is all uppercase.
         if (name.toUpperCase() !== name)

--- a/src/parser/macros.ts
+++ b/src/parser/macros.ts
@@ -167,7 +167,7 @@ export const parseArgument = (
   // If the input is a hex literal:
   if (isLiteral(input)) {
     // Get the bytes value of the operation.
-    const value = input.substring(2);
+    const value = formatEvenBytes(input.substring(2));
 
     // Get the push value
     const push = toHex(95 + value.length / 2);

--- a/src/parser/utils/contents.ts
+++ b/src/parser/utils/contents.ts
@@ -62,8 +62,8 @@ const getNestedFileContents = (
   const normalizedImports = relativeImports.map(
     (relativeImport) => path.join(dir, relativeImport)
   );
-  const fileContents: string[] = [contents];
-  const filePaths: string[] = [filePath];
+  const fileContents: string[] = [];
+  const filePaths: string[] = [];
   imported[filePath] = true;
   for (const importPath of normalizedImports) {
     if (imported[importPath]) continue;
@@ -71,9 +71,11 @@ const getNestedFileContents = (
       fileContents: importContents,
       filePaths: importPaths
     } = getNestedFileContents(importPath, imported, getFile);
-    fileContents.unshift(...importContents);
-    filePaths.unshift(...importPaths);
+    fileContents.push(...importContents);
+    filePaths.push(...importPaths);
   }
+  fileContents.push(contents);
+  filePaths.push(filePath);
   return { fileContents, filePaths };
 }
 

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -34,7 +34,7 @@ export const removeNonMatching = (arr1: any[], arr2: any[]) => {
  * Format a hex literal to make its length even
  */
 export const formatEvenBytes = (bytes: string) => {
-  if (Math.floor(bytes.length / 2) * 2 !== bytes.length) {
+  if (bytes.length % 2) {
     return `0${bytes}`;
   }
   return bytes;
@@ -54,9 +54,5 @@ export const padNBytes = (hex: string, numBytes: number) => {
   if (hex.length > numBytes * 2) {
     throw new Error(`value ${hex} has more than ${numBytes} bytes!`);
   }
-  let result = hex;
-  while (result.length < numBytes * 2) {
-    result = `0${result}`;
-  }
-  return result;
+  return hex.padStart(numBytes * 2, '0');
 };


### PR DESCRIPTION
## What this fixes

Explicitly defined constants and hex macro arguments were not being padded to an even number of bytes, which would break contracts that use hex values like `0x1`. 

Imports were being added to file contents using `contents.unshift(...importContents)`. This would import all files in reverse order, which would break expected behavior where import 2 uses things defined in import 1.

Also made some nitpicky improvements to the bytes util functions.