### PR TITLE
feat(parser): handles array args in function definitions

### DIFF
--- a/src/parser/syntax/defintions.ts
+++ b/src/parser/syntax/defintions.ts
@@ -68,7 +68,7 @@ export const HIGH_LEVEL = {
      * which is then turned into the function signature.
      * For example "example(uint, bool)"
      */
-    "((?:[\\s\\n]*)([a-zA-Z0-9_]+)(?:\\(([a-zA-Z0-9_,\\s\\n]+)?\\)))",
+    "((?:[\\s\\n]*)([a-zA-Z0-9_]+)(?:\\(([a-zA-Z0-9_\\[\\],\\s\\n]+)?\\)))",
 
     /**
      * The function type (payable, nonpayable, view, pure).
@@ -83,7 +83,7 @@ export const HIGH_LEVEL = {
     /**
      * The return type of the function within parenthesis.
      */
-    "(?:\\(([a-zA-Z0-9_,\\s\\n]+)?\\))",
+    "(?:\\(([a-zA-Z0-9_\\[\\],\\s\\n]+)?\\))",
   ]),
 
   EVENT: combineRegexElements([


### PR DESCRIPTION
Until now, the parser did not understand that function definitions in the interface can have input or output array types.

For instance, any of these two lines would break it.
```
#define function set(uint256,uint256[]) nonpayable returns ()
#define function get(uint256) view returns (uint256[])
```

The regex has been fixed and handles such cases now.